### PR TITLE
Fix: (RE) BasicResponseMessageType의 정의 수정

### DIFF
--- a/src/Data/Message.ts
+++ b/src/Data/Message.ts
@@ -1,5 +1,4 @@
 import {
-	BasicResponseMessageType,
 	ContentResponseMessageType,
 	ImageResponseCardType,
 	ResponseMessageType,
@@ -11,11 +10,13 @@ export const introMessage: ResponseMessageType = {
 	content: [
 		{
 			contentType: "PlainText",
-			content: "안녕하세요! Chat-AIDE입니다. 저에게 유방암 관련 질문을 말씀해주시면 정보를 드릴 수 있어요.",
+			content:
+				"안녕하세요! Chat-AIDE입니다. 저에게 유방암 관련 질문을 말씀해주시면 정보를 드릴 수 있어요.",
 		},
 		{
 			contentType: "PlainText",
-			content: "궁금하신 내용을 말씀해주세요. 아래의 버튼들은 사람들이 자주 묻는 질문들이에요."
+			content:
+				"궁금하신 내용을 말씀해주세요. 아래의 버튼들은 사람들이 자주 묻는 질문들이에요.",
 		},
 		{
 			contentType: "ImageResponseCard",
@@ -28,14 +29,14 @@ export const introMessage: ResponseMessageType = {
 					{
 						text: "유방암의 원인은 무엇인가요?",
 						value: "유방암의 원인은 무엇인가요",
-					}
+					},
 				],
-				title: "조직 구성(Tissue Composition)"
-			}
+				title: "조직 구성(Tissue Composition)",
+			},
 		},
 		{
 			contentType: "PlainText",
-			content : "설문조사 text test"
+			content: "설문조사 text test",
 		},
 		{
 			contentType: "ImageResponseCard",
@@ -44,15 +45,14 @@ export const introMessage: ResponseMessageType = {
 					{
 						text: "설문조사 시작하기",
 						value: "설문조사",
-					}
+					},
 				],
-				title: "설문조사"
-			}	
-		}
-	] as unknown as BasicResponseMessageType[],
+				title: "설문조사",
+			},
+		},
+	],
 	type: "response",
 };
-
 
 export const initRequest: RequestMessageType = {
 	type: "request",
@@ -65,7 +65,6 @@ export const sampleTextResponse: ContentResponseMessageType = {
 	content:
 		"정상 유방에서 유방조직(tissue composition)의 구성은 매우 다양합니다. 유방 배경 에코결은 병변 발견의 민감도에 영향을 줄 수 있습니다.",
 };
-
 
 export const sampleImageResponse: ImageResponseCardType = {
 	contentType: "ImageResponseCard",
@@ -86,7 +85,7 @@ export const sampleImageResponse: ImageResponseCardType = {
 		title: "조직 구성(Tissue Composition)",
 	},
 };
-	
+
 export const sampleCardResponse: ResponseMessageType = {
 	type: "response",
 	content: [sampleTextResponse, sampleImageResponse],

--- a/src/Interface/Message/ResponseMessageType.ts
+++ b/src/Interface/Message/ResponseMessageType.ts
@@ -1,21 +1,20 @@
 import Message from "./Message";
 
-export interface BasicResponseMessageType {
-	//aws lex response message content type
-	contentType: "PlainText" | "ImageResponseCard";
-}
+export type BasicResponseMessageType =
+	| ContentResponseMessageType
+	| ImageResponseCardType;
 
 export interface ResponseMessageType extends Message {
 	content: BasicResponseMessageType[];
 	type: "response";
 }
 
-export interface ContentResponseMessageType extends BasicResponseMessageType {
+export interface ContentResponseMessageType {
 	contentType: "PlainText";
 	content: string;
 }
 
-export interface ImageResponseCardType extends BasicResponseMessageType {
+export interface ImageResponseCardType {
 	contentType: "ImageResponseCard";
 	imageResponseCard: imageResponseCardContentType;
 }


### PR DESCRIPTION
## AS-IS

- #18 과 같은 PR이지만 이전 PR이 제대로 머지되지 않아 다시 올림

- 현재 BasicResponseMessageType은 ContentResponseMessageType과 ImageResponseType으로 extend되고 있음

  - 타입이 BasicResponseMessageType으로부터 상속, 오버로딩이 이루어져야 하는데 전혀 그렇지 않고 오히려 혼돈만 주고 있는 상황임

  - 조금 더 Typescript semantics에 맞게 type을 수정해보려고 함