### PR TITLE
Refactor: fetchRequest 로직에 addMessage 로직 추가

### DIFF
--- a/src/components/Chat/Response/Card/MessageButtons.tsx
+++ b/src/components/Chat/Response/Card/MessageButtons.tsx
@@ -20,7 +20,7 @@ export function MessageButtons({ message, messageID }: MessageButtonsProps) {
 	const { status: isLoading } = useMessageStatus();
 
 	const sendRequest = (value: string) => {
-		dispatch(fetchResponse(value));
+		dispatch(fetchResponse({ message: value, leaveMessage: false }));
 	};
 
 	const handleButtonClick = (

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -40,8 +40,7 @@ export default function MessageInput() {
 	const hiddenInputRef = useRef<HTMLInputElement>(null);
 
 	const onClick = (message: string) => {
-		dispatch(addMessage(message));
-		dispatch(fetchResponse(message));
+		dispatch(fetchResponse({ message, leaveMessage: true }));
 	};
 
 	const inputRef = useRef<HTMLInputElement>(null);

--- a/src/store/message/fetchResponse.ts
+++ b/src/store/message/fetchResponse.ts
@@ -9,25 +9,37 @@ import {
 	defaultContentResponseMessageData,
 } from "../../utils/Message/defaultResponseMessageData";
 import { getLexResponse } from "../../utils/Message/getLexResponse";
+import { addMessage } from "./messageSlice";
+
+const getResponse = async (message: string) => {
+	let content = await getLexResponse(message);
+
+	if (content === null)
+		return createResponse([
+			defaultContentResponseMessageData,
+			defaultCardResponseMessageData,
+		]);
+
+	let errorMessage = isErrorMessage(content);
+	if (errorMessage) {
+		const errorMessageContent = createResponseContent(errorMessage);
+		return createResponse(errorMessageContent);
+	}
+
+	return createResponse(content);
+};
 
 export const fetchResponse = createAsyncThunk(
 	"message/fetchResponse",
-	async (message: string) => {
-		let content = await getLexResponse(message);
-
-		if (content === null)
-			return createResponse([
-				defaultContentResponseMessageData,
-				defaultCardResponseMessageData,
-			]);
-
-		let errorMessage = isErrorMessage(content);
-		if (errorMessage) {
-			const errorMessageContent = createResponseContent(errorMessage);
-			return createResponse(errorMessageContent);
+	async (
+		{ message, leaveMessage }: { message: string; leaveMessage: boolean },
+		{ dispatch }
+	) => {
+		if (leaveMessage) {
+			dispatch(addMessage(message));
 		}
-
-		return createResponse(content);
+		const response = await getResponse(message);
+		return response;
 	}
 );
 


### PR DESCRIPTION
## AS-IS

- MessageInput과 MessageButton이 fetchRequest를 공유하는데, MessageInput은 추가적으로 addMessage action을 dispatch 해줘야 했음
  - 이러한 action을 컴포넌트에서 선언하지 않고 store로 끌어올림