### PR TITLE
Feat: responsiveness to narrower viewport width

### DIFF
--- a/src/components/Chat/BasicMessage.tsx
+++ b/src/components/Chat/BasicMessage.tsx
@@ -1,16 +1,25 @@
-import { styled } from "@mui/system";
+import styled from "@emotion/styled";
 
-export const BasicMessage = styled("div")((props: { isResponse: boolean }) => ({
-	padding: "10px 14px",
-	display: "inline-block",
+export interface isResponseInterface {
+	isResponse?: boolean;
+}
 
-	background: props.isResponse ? "#eaefef" : "#12c670",
-	borderRadius: props.isResponse ? "0px 20px 20px 20px" : "20px 0px 20px 20px",
-	alignItems: props.isResponse ? "flex-start" : "flex-end",
+export const Style =
+	(trueProp: string, falseProp: string) => (props: isResponseInterface) => {
+		return props.isResponse ? trueProp : falseProp;
+	};
 
-	color: props.isResponse ? "black" : "white",
-	border: "none",
-	boxShadow: "none",
+export const BasicMessage = styled("div")<isResponseInterface>`
+	padding: 0.5rem 0.7rem;
+	display: inline-block;
 
-	wordBreak: "keep-all",
-}));
+	background: ${Style("#eaefef", "#12c670")};
+	border-radius: ${Style("0px 1rem 1rem 1rem", "1rem 0px 1rem 1rem")};
+	align-items: ${Style("flex-start", "flex-end")};
+
+	color: ${Style("black", "white")};
+	border: none;
+	box-shadow: none;
+
+	word-break: keep-all;
+`;

--- a/src/components/Chat/LoadingResponseMessage.tsx
+++ b/src/components/Chat/LoadingResponseMessage.tsx
@@ -6,7 +6,7 @@ export const LoadingResponseMessage = () => {
 			<Stack justifyContent="flex-start" width="100%" marginTop={"-0.5rem"}>
 				<Skeleton
 					variant={"text"}
-					sx={{ fontSize: "2.5rem", width: "clamp(100px, 30%, 400px)" }}
+					sx={{ fontSize: "2.5rem", width: "clamp(6.25rem, 30%, 25rem)" }}
 					animation={"wave"}
 				/>
 			</Stack>

--- a/src/components/Chat/Request/RequestChat.tsx
+++ b/src/components/Chat/Request/RequestChat.tsx
@@ -1,6 +1,6 @@
 import { Stack, Typography } from "@mui/material";
 import RequestMessageType from "../../../Interface/Message/RequestMessageType";
-import AnimationScope from "../../../utils/Message/useMessageAnimation";
+import AnimationScope from "../../../utils/Message/AnimationScope";
 import { useSmoothScrollToBottom } from "../../../utils/chat";
 import { BasicRequestMessage } from "./BasicRequestMessage";
 

--- a/src/components/Chat/Response/Card/MessageButtons.tsx
+++ b/src/components/Chat/Response/Card/MessageButtons.tsx
@@ -37,8 +37,8 @@ export function MessageButtons({ message, messageID }: MessageButtonsProps) {
 			spacing={0.5}
 			direction={"row"}
 			flexWrap={"wrap"}
-			columnGap={"8px"}
-			rowGap={"8px"}
+			columnGap={"0.5rem"}
+			rowGap={"0.5rem"}
 			justifyContent={"flex-start"}
 			alignItems={"flex-start"}
 		>

--- a/src/components/Chat/Response/Card/StyledButton.tsx
+++ b/src/components/Chat/Response/Card/StyledButton.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { Button } from "@mui/material";
 import { primaryColor } from "../../../../utils/color";
 
 export interface IsSelectedInterface {
@@ -18,8 +17,8 @@ export const StyledButton = styled("button")<IsSelectedInterface>`
 	min-width: 50px; !important;
 
 	margin: 0 !important;
-	padding-block: 8px;
-	padding-inline: 14px;
+	padding-block: 0.6rem;
+	padding-inline: 0.8rem;
 
 	background: ${Style("white", "white")};
 	color: ${Style(primaryColor, "#6a6a6a")};
@@ -27,7 +26,7 @@ export const StyledButton = styled("button")<IsSelectedInterface>`
 	font-weight: ${Style("bold", "medium")};
 	font-size: 1rem;
 
-	border-radius: 20px;
+	border-radius: 1.25rem;
 	border: 0;
 	outline: ${Style("2px", "1px")} solid ${Style(primaryColor, "#bed1d1")};
 

--- a/src/components/Chat/Response/ContentResponseMessage.tsx
+++ b/src/components/Chat/Response/ContentResponseMessage.tsx
@@ -37,7 +37,7 @@ export default function ContentResponseMessage({
 							viewBox="0 0 24 24"
 							strokeWidth={1.5}
 							stroke="currentColor"
-							width="18px"
+							width="1.25rem"
 						>
 							<path
 								strokeLinecap="round"

--- a/src/components/Chat/Response/ResponseChat.tsx
+++ b/src/components/Chat/Response/ResponseChat.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Stack } from "@mui/material";
 import Logo from "../../../assets/logo.png";
-import AnimationScope from "../../../utils/Message/useMessageAnimation";
+import AnimationScope from "../../../utils/Message/AnimationScope";
 import { useSmoothScrollToBottom } from "../../../utils/chat";
 
 export const ResponseChat = ({ children }: { children: React.ReactNode }) => {

--- a/src/components/Chat/Response/ResponseChat.tsx
+++ b/src/components/Chat/Response/ResponseChat.tsx
@@ -11,7 +11,7 @@ export const ResponseChat = ({ children }: { children: React.ReactNode }) => {
 			<Stack
 				className="message"
 				ref={divRef}
-				gap={"8px"}
+				gap={"0.5rem"}
 				direction={"row"}
 				maxWidth={"80%"}
 			>
@@ -19,8 +19,9 @@ export const ResponseChat = ({ children }: { children: React.ReactNode }) => {
 					imgProps={{ style: { objectFit: "contain" } }}
 					alt={"ChatAI"}
 					src={Logo}
+					style={{ width: "2.2rem", height: "2.2rem" }}
 				/>
-				<Stack gap={"8px"} width={"100%"} alignItems={"start"}>
+				<Stack gap={"0.5rem"} width={"100%"} alignItems={"start"}>
 					{children}
 				</Stack>
 			</Stack>

--- a/src/components/Conversation/index.tsx
+++ b/src/components/Conversation/index.tsx
@@ -14,8 +14,8 @@ export default function Conversation() {
 			flexGrow={"1"}
 			overflow={"scroll"}
 			style={{ WebkitOverflowScrolling: "touch" }}
-			gap={"18px"}
-			paddingX={"1rem"}
+			gap={"1rem"}
+			paddingX={"0.725rem"}
 			paddingTop={"4rem"}
 			paddingBottom={"1rem"}
 		>

--- a/src/components/Conversation/style.css
+++ b/src/components/Conversation/style.css
@@ -13,7 +13,7 @@ body {
 }
 
 .chatbot-body::-webkit-scrollbar {
-	width: 8px;
+	width: 0.5rem;
 	background-color: #f5f5f5;
 }
 
@@ -121,9 +121,9 @@ body {
 
 .message-holder-left,
 .message-holder-right {
-	padding: 8px;
+	padding: 0.5rem;
 	max-width: 80%;
-	border-radius: 8px;
+	border-radius: 0.5rem;
 	margin: 10px;
 	position: relative;
 	box-shadow: 0 10px 40px -14px rgba(0, 0, 0, 0.45);
@@ -197,7 +197,7 @@ body {
 	outline: none;
 	height: 30px;
 	font-size: 0.9rem;
-	border-radius: 8px;
+	border-radius: 0.5rem;
 	display: block;
 	-webkit-box-shadow: 5px 5px 25px 0 rgba(46, 61, 73, 0.2);
 	box-shadow: 5px 5px 25px 0 rgba(46, 61, 73, 0.2);

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -42,17 +42,15 @@ export default function MessageInput() {
 	const sendRequest = async (message: string) => {
 		if (inputRef.current) inputRef.current.value = "";
 		await dispatch(fetchResponse({ message, leaveMessage: true })).unwrap();
-		onAnimationEnd();
+		inputRef.current?.focus({ preventScroll: true });
 	};
 
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	const onAnimationEnd = () => {
-		setTimeout(() => {
-			if (!inputRef?.current || !hiddenInputRef?.current) return;
-			hiddenInputRef.current.focus({ preventScroll: true });
-			inputRef.current.focus({ preventScroll: true });
-		}, 300);
+	const flushInput = () => {
+		if (!inputRef?.current || !hiddenInputRef?.current) return;
+		hiddenInputRef.current.focus({ preventScroll: true });
+		inputRef.current.focus({ preventScroll: true });
 	};
 
 	const handleOnClick = () => {
@@ -61,6 +59,8 @@ export default function MessageInput() {
 
 		const text = inputRef.current.value;
 		if (text.length === 0) return;
+
+		flushInput();
 
 		sendRequest(text);
 	};

--- a/src/index.css
+++ b/src/index.css
@@ -24,3 +24,9 @@ h1 {
 	font-size: 3.2em;
 	line-height: 1.1;
 }
+
+@media screen and (max-width: 600px) {
+	html {
+		font-size: 14px;
+	}
+}

--- a/src/utils/Message/AnimationScope.tsx
+++ b/src/utils/Message/AnimationScope.tsx
@@ -10,15 +10,19 @@ const AnimationScopeWrapper = styled("div")`
 
 export default function AnimationScope({
 	children,
+	selector,
 }: {
 	children: React.ReactNode;
+	selector?: string;
 }) {
 	const [scope, animate] = useAnimate();
+
+	const animateSelector = selector ? selector : ".message";
 
 	useEffect(() => {
 		if (scope)
 			animate(
-				".message",
+				animateSelector,
 				{
 					opacity: [0, 1],
 					y: [10, 0],


### PR DESCRIPTION
## AS-IS

- 값들이 대부분 px로 되어 있어서 모바일에서 레이아웃이 비좁게 느껴짐
- px을 rem으로 바꾸고 600px viewport width 이하에서는 font-size: 12px로 바꾸어 모바일에서 breathing space를 확보함
