### PR TITLE
Feat: normalize chat data

### DIFF
--- a/src/Interface/Message/Message.ts
+++ b/src/Interface/Message/Message.ts
@@ -1,6 +1,7 @@
+import { EntityId } from "@reduxjs/toolkit";
 import RequestMessageType from "./RequestMessageType";
 import { ResponseMessageType } from "./ResponseMessageType";
 
 export type Message = RequestMessageType | ResponseMessageType;
 
-export type MessageWithId = { id: string } & Message;
+export type WithId<T> = { id: EntityId } & T;

--- a/src/Interface/Message/ResponseMessageType.ts
+++ b/src/Interface/Message/ResponseMessageType.ts
@@ -1,3 +1,5 @@
+import { EntityId } from "@reduxjs/toolkit";
+
 export type BasicResponseMessageType =
 	| ContentResponseMessageType
 	| ImageResponseCardType;
@@ -18,7 +20,7 @@ export interface ImageResponseCardType {
 }
 
 export interface imageResponseCardContentType {
-	buttons: ButtonResponseType[];
+	buttons: ButtonResponseType[] | EntityId[];
 	imageUrl?: string;
 	subtitle?: string;
 	title?: string;

--- a/src/components/Chat/ChatChunk.tsx
+++ b/src/components/Chat/ChatChunk.tsx
@@ -1,19 +1,11 @@
-import { Stack, Typography } from "@mui/material";
 import { EntityId } from "@reduxjs/toolkit";
 import { memo } from "react";
-import {
-	BasicResponseMessageType,
-	ContentResponseMessageType,
-	ImageResponseCardType,
-} from "../../Interface/Message/ResponseMessageType";
 import { selectMessageById } from "../../store/message/messageSlice";
 import store from "../../store/store";
-import AnimationScope from "../../utils/Message/AnimationScope";
 import { useSmoothScrollToBottom } from "../../utils/chat";
-import { BasicRequestMessage } from "./Request/BasicRequestMessage";
-import CardResponseMessage from "./Response/Card/CardResponseMessage";
-import ContentResponseMessage from "./Response/ContentResponseMessage";
+import { RequestChat } from "./Request/RequestChat";
 import { ResponseChat } from "./Response/ResponseChat";
+import { ResponseChatChunk } from "./Response/ResponseChatChunk";
 
 export function ChatChunk({ messageId }: { messageId: EntityId }) {
 	const message = selectMessageById(store.getState(), messageId)!;
@@ -21,43 +13,11 @@ export function ChatChunk({ messageId }: { messageId: EntityId }) {
 
 	switch (message.type) {
 		case "request":
-			return (
-				<AnimationScope>
-					<Stack ref={divRef} maxWidth={"80%"} marginLeft={"auto"} right={"0"}>
-						<BasicRequestMessage>
-							<Typography sx={{ textAlign: "left" }}>
-								{message.message}
-							</Typography>
-						</BasicRequestMessage>
-					</Stack>
-				</AnimationScope>
-			);
+			return <RequestChat message={message} />;
 		case "response":
 			return (
 				<ResponseChat>
-					<>
-						{message.content.map(
-							(content: BasicResponseMessageType, idx: number) => {
-								switch (content.contentType) {
-									case "PlainText":
-										return (
-											<ContentResponseMessage
-												key={content.contentType + idx}
-												message={content as ContentResponseMessageType}
-											/>
-										);
-									case "ImageResponseCard":
-										return (
-											<CardResponseMessage
-												key={content.contentType + idx}
-												data={content as ImageResponseCardType}
-												messageID={`${messageId}-${idx}`}
-											/>
-										);
-								}
-							}
-						)}
-					</>
+					<ResponseChatChunk messageId={messageId} />
 				</ResponseChat>
 			);
 	}

--- a/src/components/Chat/Response/Card/CardResponseMessage.tsx
+++ b/src/components/Chat/Response/Card/CardResponseMessage.tsx
@@ -1,19 +1,17 @@
+import { Stack } from "@mui/material";
+import { EntityId } from "@reduxjs/toolkit";
 import { memo, useRef } from "react";
 import {
 	ButtonResponseType,
 	ImageResponseCardType,
 } from "../../../../Interface/Message/ResponseMessageType";
-import { BasicResponseMessage } from "../BasicResponseMessage";
-import MessageButtons from "./MessageButtons";
-import { MessageImage } from "./MessageImage";
-import { EntityId } from "@reduxjs/toolkit";
-import StyledButton from "./StyledButton";
-import { selectById } from "../../../../store/message/buttonsSlice";
-import store, { useAppDispatch } from "../../../../store/store";
-import { fetchResponse } from "../../../../store/message/fetchResponse";
-import { selectMessageById } from "../../../../store/message/messageSlice";
 import useMessageStatus from "../../../../hooks/Request/useMessageStatus";
-import { Stack } from "@mui/material";
+import { selectById } from "../../../../store/message/buttonsSlice";
+import { fetchResponse } from "../../../../store/message/fetchResponse";
+import store, { useAppDispatch } from "../../../../store/store";
+import { BasicResponseMessage } from "../BasicResponseMessage";
+import { MessageImage } from "./MessageImage";
+import StyledButton from "./StyledButton";
 
 export interface CardResponseMessageTypeProps {
 	data: ImageResponseCardType;
@@ -25,40 +23,8 @@ function MessageSubtitle({ subtitle }: { subtitle: string }) {
 
 function CardResponseMessage({ data }: CardResponseMessageTypeProps) {
 	const message = data.imageResponseCard;
-
 	const clickedBtnListRef = useRef([] as string[]);
-	const dispatch = useAppDispatch();
-	const { status: isLoading } = useMessageStatus();
 	const buttons = message.buttons || [];
-
-	const sendRequest = (value: string) => {
-		dispatch(fetchResponse({ message: value, leaveMessage: false }));
-	};
-
-	const handleButtonClick = (
-		button: ButtonResponseType,
-		buttonIndentifier: string
-	) => {
-		if (isLoading) return;
-		clickedBtnListRef.current.push(buttonIndentifier);
-		sendRequest(button.value);
-	};
-
-	const Button = memo(({ button }: { button: EntityId }) => {
-		const buttonIndentifier = button.toString();
-		const isSelected = clickedBtnListRef.current.includes(buttonIndentifier);
-		const buttonContent = selectById(store.getState().buttons, button)!;
-
-		return (
-			<StyledButton
-				disabled={isSelected}
-				id={buttonIndentifier}
-				onClick={() => handleButtonClick(buttonContent, buttonIndentifier)}
-			>
-				{buttonContent.text}
-			</StyledButton>
-		);
-	});
 
 	return (
 		<div className="message">
@@ -75,12 +41,56 @@ function CardResponseMessage({ data }: CardResponseMessageTypeProps) {
 					alignItems={"flex-start"}
 				>
 					{message.buttons.map((button) => (
-						<Button key={button.toString()} button={button as EntityId} />
+						<Button
+							clickedBtnListRef={clickedBtnListRef}
+							key={button.toString()}
+							button={button as EntityId}
+						/>
 					))}
 				</Stack>
 			)}
 		</div>
 	);
 }
+
+const Button = memo(
+	({
+		button,
+		clickedBtnListRef,
+	}: {
+		button: EntityId;
+		clickedBtnListRef: React.MutableRefObject<string[]>;
+	}) => {
+		const dispatch = useAppDispatch();
+		const { status: isLoading } = useMessageStatus();
+
+		const sendRequest = (value: string) => {
+			dispatch(fetchResponse({ message: value, leaveMessage: false }));
+		};
+
+		const handleButtonClick = (
+			button: ButtonResponseType,
+			buttonIndentifier: string
+		) => {
+			if (isLoading) return;
+			clickedBtnListRef.current.push(buttonIndentifier);
+			sendRequest(button.value);
+		};
+
+		const buttonIndentifier = button.toString();
+		const isSelected = clickedBtnListRef.current.includes(buttonIndentifier);
+		const buttonContent = selectById(store.getState().buttons, button)!;
+
+		return (
+			<StyledButton
+				disabled={isSelected}
+				id={buttonIndentifier}
+				onClick={() => handleButtonClick(buttonContent, buttonIndentifier)}
+			>
+				{buttonContent.text}
+			</StyledButton>
+		);
+	}
+);
 
 export default memo(CardResponseMessage);

--- a/src/components/Chat/Response/Card/CardResponseMessage.tsx
+++ b/src/components/Chat/Response/Card/CardResponseMessage.tsx
@@ -1,28 +1,86 @@
-import { ImageResponseCardType } from "../../../../Interface/Message/ResponseMessageType";
+import { memo, useRef } from "react";
+import {
+	ButtonResponseType,
+	ImageResponseCardType,
+} from "../../../../Interface/Message/ResponseMessageType";
 import { BasicResponseMessage } from "../BasicResponseMessage";
 import MessageButtons from "./MessageButtons";
 import { MessageImage } from "./MessageImage";
+import { EntityId } from "@reduxjs/toolkit";
+import StyledButton from "./StyledButton";
+import { selectById } from "../../../../store/message/buttonsSlice";
+import store, { useAppDispatch } from "../../../../store/store";
+import { fetchResponse } from "../../../../store/message/fetchResponse";
+import { selectMessageById } from "../../../../store/message/messageSlice";
+import useMessageStatus from "../../../../hooks/Request/useMessageStatus";
+import { Stack } from "@mui/material";
 
 export interface CardResponseMessageTypeProps {
 	data: ImageResponseCardType;
-	messageID: string;
 }
 
 function MessageSubtitle({ subtitle }: { subtitle: string }) {
 	return <BasicResponseMessage>{subtitle}</BasicResponseMessage>;
 }
 
-export default function CardResponseMessage({
-	data,
-	messageID,
-}: CardResponseMessageTypeProps) {
+function CardResponseMessage({ data }: CardResponseMessageTypeProps) {
 	const message = data.imageResponseCard;
+
+	const clickedBtnListRef = useRef([] as string[]);
+	const dispatch = useAppDispatch();
+	const { status: isLoading } = useMessageStatus();
+	const buttons = message.buttons || [];
+
+	const sendRequest = (value: string) => {
+		dispatch(fetchResponse({ message: value, leaveMessage: false }));
+	};
+
+	const handleButtonClick = (
+		button: ButtonResponseType,
+		buttonIndentifier: string
+	) => {
+		if (isLoading) return;
+		clickedBtnListRef.current.push(buttonIndentifier);
+		sendRequest(button.value);
+	};
+
+	const Button = memo(({ button }: { button: EntityId }) => {
+		const buttonIndentifier = button.toString();
+		const isSelected = clickedBtnListRef.current.includes(buttonIndentifier);
+		const buttonContent = selectById(store.getState().buttons, button)!;
+
+		return (
+			<StyledButton
+				disabled={isSelected}
+				id={buttonIndentifier}
+				onClick={() => handleButtonClick(buttonContent, buttonIndentifier)}
+			>
+				{buttonContent.text}
+			</StyledButton>
+		);
+	});
 
 	return (
 		<div className="message">
 			{message.imageUrl && <MessageImage message={message} />}
 			{message.subtitle && <MessageSubtitle subtitle={message.subtitle} />}
-			<MessageButtons message={message} messageID={messageID} />
+			{message.buttons && (
+				<Stack
+					spacing={0.5}
+					direction={"row"}
+					flexWrap={"wrap"}
+					columnGap={"0.5rem"}
+					rowGap={"0.5rem"}
+					justifyContent={"flex-start"}
+					alignItems={"flex-start"}
+				>
+					{message.buttons.map((button) => (
+						<Button key={button.toString()} button={button as EntityId} />
+					))}
+				</Stack>
+			)}
 		</div>
 	);
 }
+
+export default memo(CardResponseMessage);

--- a/src/components/Chat/Response/Card/StyledButton.tsx
+++ b/src/components/Chat/Response/Card/StyledButton.tsx
@@ -18,8 +18,8 @@ export const StyledButton = styled("button")<IsSelectedInterface>`
 	min-width: 50px; !important;
 
 	margin: 0 !important;
-	padding-block: 0.5rem;
-	padding-inline: 0.8rem;
+	padding-block: calc(0.6rem - ${Style("2px", "1px")});
+	padding-inline: calc(0.9rem - ${Style("2px", "1px")});
 
 	background: ${Style("white", "white")};
 	color: ${Style(primaryColor, "#6a6a6a")};
@@ -28,12 +28,12 @@ export const StyledButton = styled("button")<IsSelectedInterface>`
 	font-size: 1rem;
 
 	border-radius: 1.25rem;
-	border: ${Style("3px", "1px")} solid ${Style(primaryColor, "#bed1d1")};
-	margin: ${Style("-2px", "0px")};
+	border: ${Style("2px", "1px")} solid ${Style(primaryColor, "#bed1d1")};
+	// margin: ${Style("-2px", "-1px")} !important;
 
 	cursor: pointer;
 
-	transition: all 0.2s ease-in-out;
+	transition: all 0.2s linear;
 
 	&:hover {
 		background: ${Style("#f3f3f3", "#f3f3f3")};

--- a/src/components/Chat/Response/ResponseChatChunk.tsx
+++ b/src/components/Chat/Response/ResponseChatChunk.tsx
@@ -1,3 +1,4 @@
+import { EntityId } from "@reduxjs/toolkit";
 import {
 	BasicResponseMessageType,
 	ContentResponseMessageType,
@@ -6,15 +7,13 @@ import {
 } from "../../../Interface/Message/ResponseMessageType";
 import CardResponseMessage from "./Card/CardResponseMessage";
 import ContentResponseMessage from "./ContentResponseMessage";
+import store from "../../../store/store";
+import { selectMessageById } from "../../../store/message/messageSlice";
 
-export function ResponseChatChunk({
-	message,
-	messageID,
-}: {
-	message: ResponseMessageType;
-	messageID: string;
-}) {
-	const receivedResponse = message.content;
+export function ResponseChatChunk({ messageId }: { messageId: EntityId }) {
+	const message = selectMessageById(store.getState(), messageId)!;
+	const receivedResponse = message.type === "response" ? message.content : [];
+
 	return (
 		<>
 			{receivedResponse.map(
@@ -32,7 +31,6 @@ export function ResponseChatChunk({
 								<CardResponseMessage
 									key={content.contentType + idx}
 									data={content as ImageResponseCardType}
-									messageID={`${messageID}-${idx}`}
 								/>
 							);
 					}

--- a/src/components/Chat/Response/ResponseChatChunk.tsx
+++ b/src/components/Chat/Response/ResponseChatChunk.tsx
@@ -29,7 +29,7 @@ export function ResponseChatChunk({ messageId }: { messageId: EntityId }) {
 						case "ImageResponseCard":
 							return (
 								<CardResponseMessage
-									key={content.contentType + idx}
+									key={messageId.toString() + content.contentType + idx}
 									data={content as ImageResponseCardType}
 								/>
 							);

--- a/src/components/Conversation/index.tsx
+++ b/src/components/Conversation/index.tsx
@@ -21,7 +21,7 @@ export default function Conversation() {
 			paddingTop={"4rem"}
 			paddingBottom={"1rem"}
 		>
-			{messages.map((message, idx) => (
+			{messages.map((message) => (
 				<ChatChunk key={message} messageId={message} />
 			))}
 			{isLoading && (

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -118,13 +118,13 @@ function MessageInput() {
 	);
 }
 
-const PlusComponent = () => {
+const PlusComponent = memo(() => {
 	return (
 		<InputAdornment sx={{ paddingLeft: "0.5rem" }} position={"start"}>
 			<AddCircleIcon fontSize={"large"} sx={{ color: primaryColor }} />
 		</InputAdornment>
 	);
-};
+});
 
 const SendComponent = ({ handleOnClick }: { handleOnClick: () => void }) => {
 	const { status: isLoading } = useMessageStatus();

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -2,7 +2,7 @@ import AddCircleIcon from "@mui/icons-material/AddCircle";
 import SendIcon from "@mui/icons-material/Send";
 import { IconButton, InputAdornment, styled, TextField } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { KeyboardEvent, useRef } from "react";
+import { KeyboardEvent, memo, useRef } from "react";
 import useMessageStatus from "../../hooks/Request/useMessageStatus";
 import { fetchResponse } from "../../store/message/fetchResponse";
 import { useAppDispatch } from "../../store/store";
@@ -31,7 +31,7 @@ const TextFiledWrapper = styled("div")`
 	padding-inline: 0.5rem;
 `;
 
-export default function MessageInput() {
+function MessageInput() {
 	const { status: isLoading } = useMessageStatus();
 	const dispatch = useAppDispatch();
 	const classes = useStyles();
@@ -137,3 +137,5 @@ const SendComponent = ({ handleOnClick }: { handleOnClick: () => void }) => {
 		</InputAdornment>
 	);
 };
+
+export default memo(MessageInput);

--- a/src/store/message/buttonsSlice.ts
+++ b/src/store/message/buttonsSlice.ts
@@ -1,0 +1,54 @@
+import {
+	EntityId,
+	PayloadAction,
+	createEntityAdapter,
+	createSlice,
+} from "@reduxjs/toolkit";
+import { WithId } from "../../Interface/Message/Message";
+import { ButtonResponseType } from "../../Interface/Message/ResponseMessageType";
+import { introMessage } from "../../Data/Message";
+
+type ButtonWithId = WithId<ButtonResponseType>;
+
+const buttonAdapter = createEntityAdapter<ButtonWithId>();
+
+const buttons = introMessage.content.reduce((acc, cur) => {
+	if (cur.contentType !== "ImageResponseCard") return acc;
+
+	const buttonArray = cur.imageResponseCard.buttons;
+
+	const hasButtons = buttonArray.length > 0;
+	if (!hasButtons) return acc;
+
+	let buttonsId = 0;
+
+	const buttonsPayload = buttonArray.map((cur) => {
+		return {
+			id: ("button" + buttonsId++) as EntityId,
+			...(cur as ButtonResponseType),
+		} as ButtonWithId;
+	});
+
+	return { ...acc, ...buttonsPayload };
+}, [] as WithId<ButtonResponseType>[]);
+
+const initialState = buttonAdapter.addMany(
+	buttonAdapter.getInitialState(),
+	buttons
+);
+
+export const buttonsSlice = createSlice({
+	name: "buttons",
+	initialState,
+	reducers: {
+		addButtons: (state, action: PayloadAction<ButtonWithId[]>) => {
+			buttonAdapter.addMany(state, action.payload);
+		},
+	},
+});
+
+export const { addButtons } = buttonsSlice.actions;
+
+export default buttonsSlice.reducer;
+
+export const { selectById } = buttonAdapter.getSelectors();

--- a/src/store/message/fetchResponse.ts
+++ b/src/store/message/fetchResponse.ts
@@ -45,18 +45,17 @@ export const fetchResponse = createAsyncThunk<
 		if (leaveMessage) {
 			dispatch(addMessage(message));
 		}
-		const response = await getLexResponse(message);
+		let response = await getLexResponse(message);
 
 		if (response === null)
-			return createResponse([
+			response = [
 				defaultContentResponseMessageData,
 				defaultCardResponseMessageData,
-			]);
+			];
 
 		let errorMessage = isErrorMessage(response);
 		if (errorMessage) {
 			const errorMessageContent = createResponseContent(errorMessage);
-			return createResponse(errorMessageContent);
 		}
 
 		const normalizedResponse = response.map((cur) => {

--- a/src/store/message/messageSlice.ts
+++ b/src/store/message/messageSlice.ts
@@ -29,36 +29,47 @@ const initialState = messageAdapter.getInitialState<MessageState>({
 	status: "idle",
 });
 
+const testContent = introMessage.content.map((cur) => {
+	if (cur.contentType !== "ImageResponseCard") return cur;
+
+	const buttonArray = cur.imageResponseCard.buttons;
+
+	const hasButtons = buttonArray.length > 0;
+	if (!hasButtons) return cur;
+
+	let buttonsId = 0;
+
+	const buttonsPayload: WithId<ButtonResponseType>[] = buttonArray.map(
+		(cur) => {
+			return {
+				id: ("button" + buttonsId++) as EntityId,
+				...(cur as ButtonResponseType),
+			};
+		}
+	);
+
+	return {
+		...cur,
+		imageResponseCard: {
+			...cur.imageResponseCard,
+			buttons: buttonsPayload.map((cur) => cur.id),
+		},
+	};
+});
+
+// for testing
+export const manyContent = Array.from({ length: 100 }, (_, i) => {
+	return {
+		id: ("message" + i) as EntityId,
+		type: "response",
+		content: testContent,
+	};
+}) as WithId<Message>[];
+
 const initialStateWithIntroMessage = messageAdapter.addOne(initialState, {
-	id: "message0",
-	type: introMessage.type,
-	content: introMessage.content.map((cur) => {
-		if (cur.contentType !== "ImageResponseCard") return cur;
-
-		const buttonArray = cur.imageResponseCard.buttons;
-
-		const hasButtons = buttonArray.length > 0;
-		if (!hasButtons) return cur;
-
-		let buttonsId = 0;
-
-		const buttonsPayload: WithId<ButtonResponseType>[] = buttonArray.map(
-			(cur) => {
-				return {
-					id: ("button" + buttonsId++) as EntityId,
-					...(cur as ButtonResponseType),
-				};
-			}
-		);
-
-		return {
-			...cur,
-			imageResponseCard: {
-				...cur.imageResponseCard,
-				buttons: buttonsPayload.map((cur) => cur.id),
-			},
-		};
-	}),
+	id: "message0" as EntityId,
+	type: "response",
+	content: testContent,
 });
 
 export const messageSlice = createSlice({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import messageReducer from "./message/messageSlice";
+import buttonsReducer from "./message/buttonsSlice";
 
 export const store = configureStore({
 	reducer: {
 		messages: messageReducer,
+		buttons: buttonsReducer,
 	},
 });
 


### PR DESCRIPTION
## AS-IS

- 채팅 메시지가 100개가 렌더링 되어 있는 상태에서 새로운 메시지가 추가되면 약 600~700ms가 걸리고 있음
- 추가된 메시지에 대해서 리렌더링 되어야 하는 컴포넌트는 눌려진 버튼이거나 추가된 메시지인데 이렇게 오래 걸리는 것은 말도 안 된다고 판단함
  - 일반적인 유저 플로우에서 채팅이 100개 이상 존재하는 플로우가 흔하지는 않음
  - 하지만 해당 이슈는 state 관리의 목적에도 조치가 필요한 사항이라고 판단함
  - 불필요한 렌더링이 많이 일어난다는 것은 구조가 잘못되어 있기 때문, 최대한 독립적인 단위로 쪼개보고자 함

### Performance Benchmark Result

![Screenshot 2023-06-01 at 16 04 40](https://github.com/Beamworks-Inc/ChatAI-KIMES/assets/48273875/e5ef9f40-c643-49d0-b521-c8ddf8465905)
![Screenshot 2023-06-01 at 16 41 10](https://github.com/Beamworks-Inc/ChatAI-KIMES/assets/48273875/83020a91-0697-4073-8950-54c9dce21b54)

상황에 따라서 Scripting에 600 ~ 800ms가 걸림


