### PR TITLE
Fix: fix broken style for safari

### DIFF
--- a/src/Layout/Header/index.tsx
+++ b/src/Layout/Header/index.tsx
@@ -18,7 +18,6 @@ const StyledHeader = styled("div")`
 	justify-content: center;
 	background: white;
 	filter: drop-shadow(0px 10px 30px rgba(0, 0, 0, 0.1));
-	overflow-x: clip;
 	z-index: 1;
 `;
 
@@ -30,39 +29,42 @@ export default function Header() {
 	};
 
 	return (
-		<StyledHeader>
-			<HeaderSVG
-				style={{
-					position: "absolute",
-					height: "8rem",
-					marginInline: "auto",
-					flexShrink: 0,
-					pointerEvents: "none",
-					translate: "0 -0.2rem",
-				}}
-			/>
-			<Stack
-				width="100%"
-				direction={"row"}
-				justifyContent={"space-between"}
-				alignItems={"center"}
-				p={"1rem"}
-				sx={{
-					"@media (min-width: 600px)": { paddingInline: "1.5rem" },
-					isolation: "isolate",
-				}}
-				zIndex={2}
-			>
-				<HeaderButton
-					clickHandlerBuilder={(callback: () => void) => () => {
-						sendRequest(SURVEY_ACTION);
-						callback();
+		<>
+			<StyledHeader>
+				<HeaderSVG
+					style={{
+						position: "absolute",
+						height: "8rem",
+						width: "100%",
+						marginInline: "auto",
+						flexShrink: 0,
+						pointerEvents: "none",
+						translate: "0 -0.2rem",
 					}}
+				/>
+				<Stack
+					width="100%"
+					direction={"row"}
+					justifyContent={"space-between"}
+					alignItems={"center"}
+					p={"1rem"}
+					sx={{
+						"@media (min-width: 600px)": { paddingInline: "1.5rem" },
+						isolation: "isolate",
+					}}
+					zIndex={2}
 				>
-					설문조사 시작하기
-				</HeaderButton>
-				<Logo />
-			</Stack>
-		</StyledHeader>
+					<HeaderButton
+						clickHandlerBuilder={(callback: () => void) => () => {
+							sendRequest(SURVEY_ACTION);
+							callback();
+						}}
+					>
+						설문조사 시작하기
+					</HeaderButton>
+					<Logo />
+				</Stack>
+			</StyledHeader>
+		</>
 	);
 }

--- a/src/components/Chat/LoadingResponseMessage.tsx
+++ b/src/components/Chat/LoadingResponseMessage.tsx
@@ -1,8 +1,9 @@
 import { Skeleton, Stack } from "@mui/material";
+import { ANIMATION_TARGET } from "../../utils/Message/AnimationScope";
 
 export const LoadingResponseMessage = () => {
 	return (
-		<div className="message">
+		<div className={ANIMATION_TARGET}>
 			<Stack justifyContent="flex-start" width="100%" marginTop={"-0.5rem"}>
 				<Skeleton
 					variant={"text"}

--- a/src/components/Chat/Request/BasicRequestMessage.tsx
+++ b/src/components/Chat/Request/BasicRequestMessage.tsx
@@ -1,3 +1,4 @@
+import { ANIMATION_TARGET } from "../../../utils/Message/AnimationScope";
 import { BasicMessage } from "../BasicMessage";
 import { FC, ReactNode } from "react";
 
@@ -5,7 +6,7 @@ export const BasicRequestMessage: FC<{ children: ReactNode }> = ({
 	children,
 }) => {
 	return (
-		<BasicMessage className="message" isResponse={false}>
+		<BasicMessage className={ANIMATION_TARGET} isResponse={false}>
 			{children}
 		</BasicMessage>
 	);

--- a/src/components/Chat/Response/BasicResponseMessage.tsx
+++ b/src/components/Chat/Response/BasicResponseMessage.tsx
@@ -1,3 +1,4 @@
+import { ANIMATION_TARGET } from "../../../utils/Message/AnimationScope";
 import { BasicMessage } from "../BasicMessage";
 import { FC, ReactNode } from "react";
 
@@ -5,7 +6,7 @@ export const BasicResponseMessage: FC<{ children: ReactNode }> = ({
 	children,
 }) => {
 	return (
-		<BasicMessage className="message" isResponse={true}>
+		<BasicMessage className={ANIMATION_TARGET} isResponse={true}>
 			{children}
 		</BasicMessage>
 	);

--- a/src/components/Chat/Response/Card/MessageButtons.tsx
+++ b/src/components/Chat/Response/Card/MessageButtons.tsx
@@ -11,6 +11,7 @@ import {
 import { selectById } from "../../../../store/message/buttonsSlice";
 import ContentResponseMessage from "../ContentResponseMessage";
 import { errorMessage } from "../../../../utils/Message/errorMessageContent";
+import { ANIMATION_TARGET } from "../../../../utils/Message/AnimationScope";
 
 const MessageButton = memo(
 	({
@@ -22,6 +23,7 @@ const MessageButton = memo(
 	}) => {
 		const dispatch = useAppDispatch();
 		const { status: isLoading } = useMessageStatus();
+		// const isLoading = false;
 
 		const sendRequest = (value: string) => {
 			dispatch(fetchResponse({ message: value, leaveMessage: false }));
@@ -51,7 +53,7 @@ const MessageButton = memo(
 			);
 
 		return (
-			<div style={{ margin: "0" }} className="message">
+			<div style={{ margin: "0" }} className={ANIMATION_TARGET}>
 				<StyledButton
 					disabled={isSelected}
 					id={buttonIndentifier}

--- a/src/components/Chat/Response/ContentResponseMessage.tsx
+++ b/src/components/Chat/Response/ContentResponseMessage.tsx
@@ -4,6 +4,7 @@ import { containsUrl } from "../../../utils/chat";
 import { primaryColor } from "../../../utils/color";
 import { BasicResponseMessage } from "./BasicResponseMessage";
 import StyledButton from "./Card/StyledButton";
+import { ANIMATION_TARGET } from "../../../utils/Message/AnimationScope";
 
 const StyledLink = styled("a")`
 	color: #6a6a6a;
@@ -38,7 +39,7 @@ export default function ContentResponseMessage({
 
 function ResponseLink({ messageContent }: { messageContent: string }) {
 	return (
-		<div className="message" style={{ marginBottom: "8px" }}>
+		<div className={ANIMATION_TARGET} style={{ marginBottom: "8px" }}>
 			<StyledButton
 				disabled={false}
 				style={{

--- a/src/components/Chat/Response/ResponseChat.tsx
+++ b/src/components/Chat/Response/ResponseChat.tsx
@@ -1,6 +1,8 @@
 import { Avatar, Stack } from "@mui/material";
 import Logo from "../../../assets/logo.png";
-import AnimationScope from "../../../utils/Message/AnimationScope";
+import AnimationScope, {
+	ANIMATION_TARGET,
+} from "../../../utils/Message/AnimationScope";
 import { useSmoothScrollToBottom } from "../../../utils/chat";
 
 export const ResponseChat = ({ children }: { children: React.ReactNode }) => {
@@ -9,7 +11,7 @@ export const ResponseChat = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<AnimationScope>
 			<Stack
-				className="message"
+				className={ANIMATION_TARGET}
 				ref={divRef}
 				gap={"0.5rem"}
 				direction={"row"}

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -136,8 +136,8 @@ const HomeComponent = () => {
 				background: primaryColor,
 				borderRadius: "100vh",
 				aspectRatio: "1 / 1",
-				placeContent: "center",
-				padding: "0.65rem",
+				height: "3rem",
+				placeItems: "center",
 				minWidth: 0,
 			}}
 		>

--- a/src/utils/Message/AnimationScope.tsx
+++ b/src/utils/Message/AnimationScope.tsx
@@ -8,6 +8,9 @@ const AnimationScopeWrapper = styled("div")`
 	width: 100%;
 `;
 
+export const ANIMATION_TARGET = "animation-target";
+const ANIMATION_TARGET_SELECTOR = `.${ANIMATION_TARGET}`;
+
 export default function AnimationScope({
 	children,
 	selector,
@@ -17,7 +20,7 @@ export default function AnimationScope({
 }) {
 	const [scope, animate] = useAnimate();
 
-	const animateSelector = selector ? selector : ".message";
+	const animateSelector = selector ? selector : ANIMATION_TARGET_SELECTOR;
 
 	useEffect(() => {
 		if (scope)


### PR DESCRIPTION
- Safari에서 헤더 부분의 svg가 overflow된 부분이 잘리는 현상
  - wrapper 자체의 overflow를 지우고 svg 자체에 max-width를 걸어 길이를 제한함
- 입력 창의 홈 버튼의 정렬이 어색한 점
  - safari에서는 padding이 있는 element에 대해서 aspect-ratio을 줄 때 height를 지정해버리는 게 원하는 비율을 맞추는 방법인 것 같음