### PR TITLE
Fix/android-chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 	<head>
 		<meta charset="UTF-8" />
 		<link rel="icon" type="image/svg+xml" href="icons/logo.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-visual"
+		/>
 		<title>ChatAI</title>
 	</head>
 	<body>

--- a/src/components/Conversation/index.tsx
+++ b/src/components/Conversation/index.tsx
@@ -90,7 +90,7 @@ export default function Conversation() {
 				style={{
 					opacity: showScrollToTop ? 1 : 0,
 					visibility: showScrollToTop ? "visible" : "hidden",
-					position: "fixed",
+					position: "absolute",
 					left: "auto",
 					right: "1rem",
 					bottom: `calc(5rem + ${keyboardHeight}px)`,

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -81,7 +81,7 @@ function MessageInput() {
 
 	return (
 		<>
-			<TextFiledWrapper>
+			<TextFiledWrapper className="message-input">
 				<HomeComponent />
 				<TextField
 					inputProps={{

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,5 @@
 :root {
 	font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-	/* line-height: 1.5; */
 	font-weight: 400;
 	font-synthesis: none;
 }
@@ -9,10 +8,10 @@
 	position: absolute;
 	top: 0px;
 	width: 100vw;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
-	/* transition: bottom 100ms ease-in-out; */
 }
 
 body {

--- a/src/utils/Mobile/mobile.ts
+++ b/src/utils/Mobile/mobile.ts
@@ -3,34 +3,27 @@ export const windowHeight = window.innerHeight;
 export const root = document.getElementById("root");
 export const visualViewport = window.visualViewport;
 
-export const scrollToTop = () => {
-	window.scrollTo(0, 0);
+export const pushDownTop = () => {
+	const offsetTop = visualViewport?.offsetTop || 0;
+	if (root) root.style.top = offsetTop + "px";
 };
 
-const scrollToTopTimeout = () => {
-	setTimeout(() => {
-		scrollToTop();
-	}, 500);
+const pushDownTopTimeout = () => {
+	const offsetTop = visualViewport?.offsetTop || 0;
+	if (root) root.style.top = offsetTop + "px";
 };
 
 export const addScrollEventListener = () => {
-	scrollToTop();
-	window.addEventListener("scroll", scrollToTopTimeout);
+	visualViewport?.addEventListener("scroll", pushDownTopTimeout);
 };
 
 export const removeScrollEventListener = () => {
-	window.removeEventListener("scroll", scrollToTopTimeout);
-};
-
-export const setBottom = (bottom: number) => {
-	if (!root) return;
-
-	root.style.bottom = bottom + "px";
+	if (root) root.style.top = "0px";
+	visualViewport?.removeEventListener("scroll", pushDownTopTimeout);
 };
 
 export default function setWindowHeight() {
 	document.body.style.height = `${windowHeight}px`;
-	if (root) setBottom(0);
 }
 
 export function detectSamsungBrowser() {


### PR DESCRIPTION
## AS-IS

- android chrome에서 meta content 중 interactive-widget이 제대로 동작하지 않아 가상 키보드가 노출될 때 scroll이 되는 현상이 있음

- android chrome에서 scroll이 될 때 window, body가 아닌 visualViewport로 해당 scroll event를 listen 함

- 가상 키보드 노출 시 메시지 입력 창을 아래에서 올리는 것 보다 높이를 줄이고 맨 위를 내리는 것이 더 간단하다고 판단함