### PR TITLE
Fix: Push 'Button Pushed State' upto the Store

### DIFF
--- a/src/components/Chat/Response/Card/CardResponseMessage.tsx
+++ b/src/components/Chat/Response/Card/CardResponseMessage.tsx
@@ -1,24 +1,24 @@
 import { Stack, styled } from "@mui/material";
 import { EntityId } from "@reduxjs/toolkit";
-import { memo, useRef } from "react";
+import { memo } from "react";
 import { ImageResponseCardType } from "../../../../Interface/Message/ResponseMessageType";
 import { BasicResponseMessage } from "../BasicResponseMessage";
 import { MessageImage } from "./MessageImage";
 import MessageButton from "./MessageButtons";
+import { useAppDispatch } from "../../../../store/store";
+import { pushButton } from "../../../../store/message/buttonsSlice";
 
 export interface CardResponseMessageTypeProps {
 	data: ImageResponseCardType;
 }
 
 function CardResponseMessage({ data }: CardResponseMessageTypeProps) {
+	const dispatch = useAppDispatch();
 	const message = data.imageResponseCard;
-	const clickedBtnListRef = useRef([] as string[]);
 
 	const addClickedBtn = (buttonIndentifier: string) => {
-		clickedBtnListRef.current.push(buttonIndentifier);
+		dispatch(pushButton(buttonIndentifier));
 	};
-	const checkBtnClicked = (buttonIndentifier: string) =>
-		clickedBtnListRef.current.includes(buttonIndentifier);
 
 	return (
 		<>
@@ -30,7 +30,6 @@ function CardResponseMessage({ data }: CardResponseMessageTypeProps) {
 						<MessageButton
 							key={button.toString()}
 							buttonId={button as EntityId}
-							checkBtnClicked={checkBtnClicked}
 							addClickedBtn={addClickedBtn}
 						/>
 					))}

--- a/src/components/Chat/Response/Card/MessageButtons.tsx
+++ b/src/components/Chat/Response/Card/MessageButtons.tsx
@@ -10,20 +10,18 @@ import StyledButton from "./StyledButton";
 const MessageButton = ({
 	buttonId,
 	addClickedBtn,
-	checkBtnClicked,
 }: {
 	buttonId: EntityId;
 	addClickedBtn: (buttonIndentifier: string) => void;
-	checkBtnClicked: (buttonIndentifier: string) => boolean;
 }) => {
 	const dispatch = useAppDispatch();
 	const isLoading = useAppSelector(isMessageStatusLoading);
 	const buttonContent = useAppSelector((state) =>
 		selectById(state.buttons, buttonId)
-	);
+	)!;
 
 	const buttonIndentifier = buttonId.toString();
-	const isClicked = checkBtnClicked(buttonIndentifier);
+	const isClicked = buttonContent.pushed;
 
 	if (!buttonContent) return <ErrorMessage />;
 

--- a/src/store/message/buttonsSlice.ts
+++ b/src/store/message/buttonsSlice.ts
@@ -7,10 +7,12 @@ import {
 import { WithId } from "../../Interface/Message/Message";
 import { ButtonResponseType } from "../../Interface/Message/ResponseMessageType";
 import { introMessage } from "../../Data/Message";
+import { RootState } from "../store";
 
-type ButtonWithId = WithId<ButtonResponseType>;
+type PushableButtonType = ButtonResponseType & { pushed: boolean };
+type PushableButtonWithId = WithId<PushableButtonType>;
 
-const buttonAdapter = createEntityAdapter<ButtonWithId>();
+const buttonAdapter = createEntityAdapter<PushableButtonWithId>();
 
 const buttons = introMessage.content.reduce((acc, cur) => {
 	if (cur.contentType !== "ImageResponseCard") return acc;
@@ -25,12 +27,13 @@ const buttons = introMessage.content.reduce((acc, cur) => {
 	const buttonsPayload = buttonArray.map((cur) => {
 		return {
 			id: ("button" + buttonsId++) as EntityId,
+			pushed: false,
 			...(cur as ButtonResponseType),
-		} as ButtonWithId;
+		} as PushableButtonWithId;
 	});
 
 	return { ...acc, ...buttonsPayload };
-}, [] as WithId<ButtonResponseType>[]);
+}, [] as WithId<PushableButtonWithId>[]);
 
 const initialState = buttonAdapter.addMany(
 	buttonAdapter.getInitialState(),
@@ -41,13 +44,37 @@ export const buttonsSlice = createSlice({
 	name: "buttons",
 	initialState,
 	reducers: {
-		addButtons: (state, action: PayloadAction<ButtonWithId[]>) => {
-			buttonAdapter.addMany(state, action.payload);
+		addButtons: (
+			state,
+			action: PayloadAction<WithId<ButtonResponseType>[]>
+		) => {
+			buttonAdapter.addMany(
+				state,
+				action.payload.map((cur) => {
+					return {
+						...cur,
+						pushed: false,
+					};
+				})
+			);
+		},
+		pushButton: (state, action: PayloadAction<EntityId>) => {
+			buttonAdapter.updateOne(state, {
+				id: action.payload,
+				changes: {
+					pushed: true,
+				},
+			});
 		},
 	},
 });
 
-export const { addButtons } = buttonsSlice.actions;
+export const { addButtons, pushButton } = buttonsSlice.actions;
+
+export const checkButtonPushed = (buttonId: EntityId) => (state: RootState) => {
+	const button = selectById(state.buttons, buttonId)!;
+	return button.pushed;
+};
 
 export default buttonsSlice.reducer;
 


### PR DESCRIPTION
## AS-IS

- 버튼의 눌림 여부를 useRef를 통해 컴포넌트에서 관리하고 있었음
- state management를 하면서 그럴 필요가 없어졌고 해당 state를 상위로 끌어올려 관리할 필요가 생김