### PR TITLE
Fix: change html lang to `ko`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 	<head>
 		<meta charset="UTF-8" />
+		<meta name="google" content="notranslate" />
+		<meta http-equiv="Content-Language" content="ko" />
 		<link rel="icon" type="image/svg+xml" href="icons/logo.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="interactive-widget" content="resizes-visual" />


### PR DESCRIPTION
## AS-IS

- 기본으로 설정된 값은 html lang="en"이었음

- 그래서 어떤 브라우저에서는 해당 페이지를 번역하려고 함

- 번역 결과가 매우 부자연스러워 사용자 경험을 해침

- 페이지 언어를 한글로 명시하고 자동 번역 기능을 끄고자 함