### PR TITLE
Fix: scroll to nearest block when keyboard is up

### DIFF
--- a/src/components/Chat/Response/Card/CardResponseMessage.tsx
+++ b/src/components/Chat/Response/Card/CardResponseMessage.tsx
@@ -44,11 +44,11 @@ function MessageSubtitle({ subtitle }: { subtitle: string }) {
 }
 
 const MessageButtons = styled(Stack)`
-	spacing: 0.5rem;
+	spacing: clamp(8px, 0.3rem, 16px);
 	flex-direction: row;
 	flex-wrap: wrap;
-	column-gap: 0.5rem;
-	row-gap: 0.5rem;
+	column-gap: clamp(8px, 0.3rem, 12px);
+	row-gap: clamp(8px, 0.3rem, 12px);
 	justify-content: flex-start;
 	align-items: flex-start;
 `;

--- a/src/components/Chat/Response/Card/StyledButton.tsx
+++ b/src/components/Chat/Response/Card/StyledButton.tsx
@@ -22,29 +22,29 @@ export const StyledButton = styled("button")<IsSelectedInterface>`
 	padding-block: clamp(6px, 0.5rem, 18px);
 	padding-inline: clamp(8px, 0.8rem, 22px);
 
-	background: ${Style(primaryColor, "white")};
-	color: ${Style("white", "#6a6a6a")};
+	background: ${Style("hsl(135 60% 75%)", "white")};
+	color: ${Style("hsl(135 20% 20%)", "#6a6a6a")};
 	text-align: start;
-	font-weight: ${Style("700", "500")};
+	font-weight: 500;
 	font-size: 1rem;
 
 	border-radius: 1.25rem;
-	border: ${Style("2px", "1px")} solid ${Style("#366344", "#cacfcf")};
+	border: clamp(1px, 0.1rem, 10px) solid ${Style("#366344", "#cacfcf")};
 
 	cursor: pointer;
 
 	transition: background 0.2s linear;
 
 	&:hover {
-		background: ${Style(primaryColor, "#f3f3f3")};
+		background: ${Style("hsl(135 50% 60%)", "#f3f3f3")};
 	}
 
 	&:focus {
-		background: ${Style(primaryColor, "#f3f3f3")};
+		background: ${Style("hsl(135 50% 60%)", "#f3f3f3")};
 	}
 
 	&:active {
-		background: ${Style(primaryColor, "#e1e1e1")};
+		background: ${Style("hsl(135 50% 60%)", "#e1e1e1")};
 	}
 `;
 

--- a/src/components/Chat/Response/ResponseChat.tsx
+++ b/src/components/Chat/Response/ResponseChat.tsx
@@ -9,7 +9,7 @@ export const ResponseChat = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<AnimationScope>
 			<Stack
-				gap={"0.5rem"}
+				gap={"clamp(8px, 0.5rem, 16px)"}
 				maxWidth={CHAT_MAX_WIDTH}
 				sx={{
 					flexDirection: "row",
@@ -19,7 +19,11 @@ export const ResponseChat = ({ children }: { children: React.ReactNode }) => {
 				}}
 			>
 				<MemoizedAvatar />
-				<Stack gap={"0.5rem"} width={"100%"} alignItems={"start"}>
+				<Stack
+					gap={"clamp(12px, 0.5rem, 16px)"}
+					width={"100%"}
+					alignItems={"start"}
+				>
 					{children}
 				</Stack>
 			</Stack>

--- a/src/components/Conversation/Focus/useFocusedMessage.tsx
+++ b/src/components/Conversation/Focus/useFocusedMessage.tsx
@@ -6,15 +6,21 @@ import { useAppSelector } from "../../../store/store";
 export function useFocusedMessage(messageId: EntityId) {
 	const isFocusedMessage = useAppSelector(selectFocusedMessageId(messageId));
 	const messageRef = useRef<HTMLDivElement>(null);
+	const isKeyboardUp = useAppSelector(
+		(state) => state.keyboard.bottomPadding > 0
+	);
 
 	useEffect(() => {
-		if (isFocusedMessage && messageRef.current) {
-			messageRef.current.scrollIntoView({
-				behavior: "smooth",
-				block: "start",
-				inline: "nearest",
-			});
-		}
+		requestAnimationFrame(() => {
+			if (isFocusedMessage && messageRef.current) {
+				messageRef.current.style.scrollPaddingBottom = "80vh";
+				messageRef.current.scrollIntoView({
+					behavior: "smooth",
+					block: isKeyboardUp ? "nearest" : "start",
+					inline: "nearest",
+				});
+			}
+		});
 	}, [isFocusedMessage]);
 
 	return { isFocusedMessage, messageRef };


### PR DESCRIPTION
## AS-IS

- 키보드 노출 시 스크롤을 가장 가까운 블럭으로 하도록 함
  - 이전에는 높이가 짧은 메시지가 답변으로 올 때 입력 창까지 밀려올라가는 이슈가 있었음
- gap 등의 rem 값들을 clamp를 이용해 responsive하게 바꿈
- 버튼 컬러를 조금 더 readable하게 수정