### PR TITLE
Fix: tree-shake mui library + resolve circular dependency of keyboard handling logic

### DIFF
--- a/src/Layout/Header/HeaderButton.tsx
+++ b/src/Layout/Header/HeaderButton.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Button } from "@mui/material";
+import Button from "@mui/material/Button";
 import { ReactNode, useState } from "react";
 import { primaryColor } from "../../utils/color";
 

--- a/src/Layout/Header/Logo.tsx
+++ b/src/Layout/Header/Logo.tsx
@@ -1,6 +1,10 @@
-import { Box, ButtonBase, Modal, Slider, Typography } from "@mui/material";
-import ChatAIDE from "../../assets/ChatAI-B.png";
+import Box from "@mui/material/Box";
+import ButtonBase from "@mui/material/ButtonBase";
+import Modal from "@mui/material/Modal";
+import Slider from "@mui/material/Slider";
+import Typography from "@mui/material/Typography";
 import { useState } from "react";
+import ChatAIDE from "../../assets/ChatAI-B.png";
 
 const html = document.querySelector("html");
 

--- a/src/Layout/Header/index.tsx
+++ b/src/Layout/Header/index.tsx
@@ -1,4 +1,5 @@
-import { Stack, styled } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import styled from "@mui/material/styles/styled";
 
 import HeaderButton from "./HeaderButton";
 import { Logo } from "./Logo";

--- a/src/components/Chat/Request/RequestChat.tsx
+++ b/src/components/Chat/Request/RequestChat.tsx
@@ -1,4 +1,5 @@
-import { Stack, Typography } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
 import RequestMessageType from "../../../Interface/Message/RequestMessageType";
 import AnimationScope from "../../../utils/Message/AnimationScope";
 import { CHAT_MAX_WIDTH } from "../Response/ResponseChat";

--- a/src/components/Chat/Response/Card/CardResponseMessage.tsx
+++ b/src/components/Chat/Response/Card/CardResponseMessage.tsx
@@ -1,12 +1,13 @@
-import { Stack, styled } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import styled from "@mui/material/styles/styled";
 import { EntityId } from "@reduxjs/toolkit";
 import { memo } from "react";
 import { ImageResponseCardType } from "../../../../Interface/Message/ResponseMessageType";
-import { BasicResponseMessage } from "../BasicResponseMessage";
-import { MessageImage } from "./MessageImage";
-import MessageButton from "./MessageButtons";
-import { useAppDispatch } from "../../../../store/store";
 import { pushButton } from "../../../../store/message/buttonsSlice";
+import { useAppDispatch } from "../../../../store/store";
+import { BasicResponseMessage } from "../BasicResponseMessage";
+import MessageButton from "./MessageButtons";
+import { MessageImage } from "./MessageImage";
 
 export interface CardResponseMessageTypeProps {
 	data: ImageResponseCardType;

--- a/src/components/Chat/Response/Card/MessageImage.tsx
+++ b/src/components/Chat/Response/Card/MessageImage.tsx
@@ -1,8 +1,7 @@
-import { Typography } from "@mui/material";
+import Typography from "@mui/material/Typography";
 import styled from "@mui/system/styled";
-import { BasicResponseMessage } from "../BasicResponseMessage";
 import { imageResponseCardContentType } from "../../../../Interface/Message/ResponseMessageType";
-import { ANIMATION_TARGET } from "../../../../utils/Message/AnimationScope";
+import { BasicResponseMessage } from "../BasicResponseMessage";
 
 const StyledImg = styled("img")`
 	border-radius: 1rem;

--- a/src/components/Chat/Response/ContentResponseMessage.tsx
+++ b/src/components/Chat/Response/ContentResponseMessage.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@mui/material";
+import Typography from "@mui/material/Typography";
 import { memo, useMemo } from "react";
 import { ContentResponseMessageType } from "../../../Interface/Message/ResponseMessageType";
 import { containsUrl } from "../../../utils/chat";

--- a/src/components/Chat/Response/ResponseChat.tsx
+++ b/src/components/Chat/Response/ResponseChat.tsx
@@ -1,7 +1,8 @@
-import { Avatar, Stack } from "@mui/material";
+import Avatar from "@mui/material/Avatar";
+import Stack from "@mui/material/Stack";
+import { memo } from "react";
 import Logo from "../../../assets/logo.png";
 import AnimationScope from "../../../utils/Message/AnimationScope";
-import { memo } from "react";
 
 export const CHAT_MAX_WIDTH = "90%";
 

--- a/src/components/Conversation/Focus/FocusableChatChunk.tsx
+++ b/src/components/Conversation/Focus/FocusableChatChunk.tsx
@@ -1,9 +1,9 @@
+import styled from "@mui/material/styles/styled";
 import { EntityId } from "@reduxjs/toolkit";
 import { memo } from "react";
+import { ANIMATION_TARGET } from "../../../utils/Message/AnimationScope";
 import { ChatChunk } from "../../Chat/ChatChunk";
 import { useFocusedMessage } from "./useFocusedMessage";
-import { styled } from "@mui/material";
-import { ANIMATION_TARGET } from "../../../utils/Message/AnimationScope";
 
 const setColor = (weight: number) => (props: { focusedStyle: boolean }) =>
 	props.focusedStyle ? `hsl(130 ${weight}% 70% / 0.6)` : "transparent";

--- a/src/components/Conversation/LoadingResponseMessage.tsx
+++ b/src/components/Conversation/LoadingResponseMessage.tsx
@@ -1,4 +1,5 @@
-import { Skeleton, Stack } from "@mui/material";
+import Skeleton from "@mui/material/Skeleton";
+import Stack from "@mui/material/Stack";
 import { ANIMATION_TARGET } from "../../utils/Message/AnimationScope";
 import ResponseChat from "../Chat/Response/ResponseChat";
 

--- a/src/components/Conversation/Scroll/ScrollButton.tsx
+++ b/src/components/Conversation/Scroll/ScrollButton.tsx
@@ -1,7 +1,8 @@
-import {
-	ArrowDownwardOutlined,
-	ArrowUpwardOutlined,
-} from "@mui/icons-material";
+import styled from "@emotion/styled";
+import ArrowDownwardOutlined from "@mui/icons-material/ArrowDownwardOutlined";
+import ArrowUpwardOutlined from "@mui/icons-material/ArrowUpwardOutlined";
+import IconButton from "@mui/material/IconButton";
+import { ReactElement } from "react";
 import {
 	getNextMessage,
 	getPreviousMessage,
@@ -9,9 +10,6 @@ import {
 	hasMessageReachedTop,
 } from "../../../store/message/messageSlice";
 import { useAppDispatch, useAppSelector } from "../../../store/store";
-import styled from "@emotion/styled";
-import { IconButton } from "@mui/material";
-import { ReactElement } from "react";
 
 export function ScrollButton() {
 	const dispatch = useAppDispatch();

--- a/src/components/Conversation/index.tsx
+++ b/src/components/Conversation/index.tsx
@@ -1,4 +1,7 @@
-import { Stack, styled } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import styled from "@mui/material/styles/styled";
+import BeamworksLogo from "../../assets/BeamworksLogo.png";
+import { pullInputDown } from "../../store/keyboard/keyboardSlice";
 import {
 	isMessageStatusLoading,
 	selectMessageIds,
@@ -8,8 +11,6 @@ import FocusableChatChunk from "./Focus/FocusableChatChunk";
 import { LoadingResponseMessage } from "./LoadingResponseMessage";
 import { ScrollButton } from "./Scroll/ScrollButton";
 import { useScrollToBottom } from "./Scroll/useScrollToBottom";
-import BeamworksLogo from "../../assets/BeamworksLogo.png";
-import { pullInputDown } from "../../store/keyboard/keyboardSlice";
 
 export default function Conversation() {
 	const isLoading = useAppSelector(isMessageStatusLoading);

--- a/src/components/MenuButton/index.tsx
+++ b/src/components/MenuButton/index.tsx
@@ -1,5 +1,5 @@
 import MenuIcon from "@mui/icons-material/Menu";
-import { IconButton } from "@mui/material";
+import IconButton from "@mui/material/IconButton";
 
 export default function MenuButton() {
 	return (

--- a/src/components/MessageInput/HomeButton.tsx
+++ b/src/components/MessageInput/HomeButton.tsx
@@ -1,12 +1,12 @@
-import { HomeRounded } from "@mui/icons-material";
-import { IconButton } from "@mui/material";
+import HomeRounded from "@mui/icons-material/HomeRounded";
+import IconButton from "@mui/material/IconButton";
+import { pullInputDown } from "../../store/keyboard/keyboardSlice";
 import {
 	DEFAULT_MESSAGE,
 	fetchResponse,
 } from "../../store/message/fetchResponse";
 import { useAppDispatch } from "../../store/store";
 import { primaryColor } from "../../utils/color";
-import { pullInputDown } from "../../store/keyboard/keyboardSlice";
 
 export const HomeButton = () => {
 	const dispatch = useAppDispatch();

--- a/src/components/MessageInput/RotatingRefreshIcon.tsx
+++ b/src/components/MessageInput/RotatingRefreshIcon.tsx
@@ -1,11 +1,14 @@
 import RefreshIcon from "@mui/icons-material/Refresh";
-import { keyframes, styled } from "@mui/material";
-
-export const rotate = keyframes`
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-  `;
+import styled from "@mui/material/styles/styled";
 
 export const RotatingRefreshIcon = styled(RefreshIcon)`
-	animation: ${rotate} 1s linear infinite;
+	@keyframes rotate {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
+	}
+	animation: rotate 1s linear infinite;
 `;

--- a/src/components/MessageInput/SendComponent.tsx
+++ b/src/components/MessageInput/SendComponent.tsx
@@ -1,8 +1,9 @@
 import SendIcon from "@mui/icons-material/Send";
-import { IconButton, InputAdornment } from "@mui/material";
-import { RotatingRefreshIcon } from "./RotatingRefreshIcon";
-import { useAppSelector } from "../../store/store";
+import IconButton from "@mui/material/IconButton";
+import InputAdornment from "@mui/material/InputAdornment";
 import { isMessageStatusLoading } from "../../store/message/messageSlice";
+import { useAppSelector } from "../../store/store";
+import { RotatingRefreshIcon } from "./RotatingRefreshIcon";
 
 export const SendComponent = ({
 	handleOnClick,

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -46,7 +46,7 @@ function MessageInput() {
 					}
 					onKeyDown={(e) => handleTextFieldKey(e)}
 					onFocus={() => {
-						addKeyboardPopupListener();
+						dispatch(addKeyboardPopupListener());
 						dispatch(pushInputUp);
 					}}
 					inputProps={{

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,15 +1,16 @@
-import { styled, TextField } from "@mui/material";
+import styled from "@mui/material/styles/styled";
+import TextField from "@mui/material/TextField";
 import { forwardRef, KeyboardEvent, memo, useEffect } from "react";
-import { SendComponent } from "./SendComponent";
-import { HomeButton } from "./HomeButton";
-import { useSendRequest } from "./useSendRequest";
-import { useAppDispatch, useAppSelector } from "../../store/store";
+import { addKeyboardPopupListener } from "../../store/keyboard/keyboardEventHandler";
+import { pushInputUp } from "../../store/keyboard/keyboardSlice";
 import {
 	hasMessageReachedBottom,
 	isMessageStatusLoading,
 } from "../../store/message/messageSlice";
-import { addKeyboardPopupListener } from "../../store/keyboard/keyboardEventHandler";
-import { pushInputUp } from "../../store/keyboard/keyboardSlice";
+import { useAppDispatch, useAppSelector } from "../../store/store";
+import { HomeButton } from "./HomeButton";
+import { SendComponent } from "./SendComponent";
+import { useSendRequest } from "./useSendRequest";
 
 const ENTER_KEY_HINT = "send";
 const INPUT_TYPE = "search";

--- a/src/store/keyboard/keyboardEventHandler.ts
+++ b/src/store/keyboard/keyboardEventHandler.ts
@@ -1,19 +1,20 @@
-import store from "../store";
+import { AppDispatch } from "../store";
 import { handleKeyboardPopup, pushInputUp } from "./keyboardSlice";
 
 const root = document.getElementById("root");
 
-export const addKeyboardPopupListener = () => {
-	store.dispatch(pushInputUp());
-	visualViewport?.addEventListener("resize", mobileKeyboardHandler);
+export const addKeyboardPopupListener = () => (dispatch: AppDispatch) => {
+	dispatch(pushInputUp());
+	visualViewport?.addEventListener("resize", mobileKeyboardHandler(dispatch));
 };
 
 export const removeKeyboardPopupListener = () => {
-	visualViewport?.removeEventListener("resize", mobileKeyboardHandler);
+	visualViewport?.removeEventListener("resize", mobileKeyboardHandler(null));
 };
 
-const mobileKeyboardHandler = () => {
-	store.dispatch(handleKeyboardPopup());
+const mobileKeyboardHandler = (dispatch: AppDispatch | null) => () => {
+	if (!dispatch) return;
+	dispatch(handleKeyboardPopup());
 };
 
 export const addScrollEventListener = () => {


### PR DESCRIPTION
## AS-IS

- mui library가 통째로 로드되어 build된 앱 기준 index.js가 총 444kB 정도 로드됨
  - 필요한 부분만 로드하면 148kB로 줄어 듦
- tree shake하는 중에 잘못 작성한 redux 코드 발견
  - store.dispatch 관련 circular dependency가 있어 첫 렌더부터 에러가 남
  - dispatch를 store에서 가져오는 것이 아니라 인자로 주입받도록 수정